### PR TITLE
Replace Depfu with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    cooldown:
+      default-days: 3
+    groups:
+      routine-dependencies:
+        patterns:
+          - "*"
+    versioning-strategy: increase
+    open-pull-requests-limit: 2
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: America/Los_Angeles
+    cooldown:
+      default-days: 3
+    groups:
+      routine-actions:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 _Emoji Object Notation_
 
 [![CI](https://github.com/agorischek/emojion/actions/workflows/ci.yml/badge.svg)](https://github.com/agorischek/emojion/actions/workflows/ci.yml)
-[![Dependencies](https://img.shields.io/depfu/agorischek/emojion.svg)](https://depfu.com/repos/agorischek/emojion)
 [![Version](https://img.shields.io/npm/v/emj.svg)](https://www.npmjs.com/package/emj)
 [![License](https://img.shields.io/github/license/agorischek/emojion.svg)](https://github.com/agorischek/emojion/blob/master/LICENSE)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1686,9 +1686,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What changed

- add grouped weekly Dependabot updates for npm and GitHub Actions
- wait three days before routine version updates
- cap open update pull requests to keep the queue small
- remove the obsolete Depfu badge
- refresh the transitive brace-expansion lock entry to its patched release

## Why

Depfu still has GitHub App access to Emojion and was opening security updates in 2026. Package Sitter has already migrated. This retires the remaining actively updating Depfu repository without creating an ungrouped dependency PR firehose.

The first CI run also exposed the newly published high-severity brace-expansion advisory on the default-branch lockfile; npm resolved it without changing Emojion direct dependencies.

## Validation

- Dependabot YAML parses successfully
- npm audit --audit-level=moderate — zero vulnerabilities
- npm ci --ignore-scripts
- npm run lint
- npm test — 66 passing
- npm run build
- git diff --check
- CodeRabbit CLI review — zero findings