### PR TITLE
Keep Dependabot branches current

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       timezone: America/Los_Angeles
     cooldown:
       default-days: 7
+    rebase-strategy: auto
     versioning-strategy: increase-if-necessary
     groups:
       development-routine:
@@ -55,6 +56,7 @@ updates:
       timezone: America/Los_Angeles
     cooldown:
       default-days: 7
+    rebase-strategy: auto
     groups:
       routine-actions:
         patterns:


### PR DESCRIPTION
Explicitly retain Dependabot’s automatic rebase behavior for both npm and GitHub Actions updates. Merging this also initiates the post-onboarding update check used for the Garden canary.

Validation: Dependabot YAML parsed successfully and `git diff --check` passed.