### PR TITLE
Update Prettier formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ with `⏰` (because alarms are annoying).
 
 In keys, Unicode characters can be encoded using `🌎` followed by fruit, such as
 `🌎🍏🍊🍈🍓` for `U+0398` (which is `Θ`). In values, Unicode characters are
-encoded using `🗺` followed by office supplies, such as `🗺🖋🖊🧷🔎` for
-`U+0394` (which is `Δ`).
+encoded using `🗺` followed by office supplies, such as `🗺🖋🖊🧷🔎` for `U+0394`
+(which is `Δ`).
 
 See [`characters.ts`](./src/characters.ts) for the full character map.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-prettier": "^5.5.5",
         "globals": "^17.6.0",
         "npm-check-updates": "^22.1.1",
-        "prettier": "^3.8.3",
+        "prettier": "^3.9.6",
         "replace-in-file": "^8.4.0",
         "rimraf": "^6.1.3",
         "rollup": "^4.60.3",
@@ -3040,9 +3040,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+      "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint-plugin-prettier": "^5.5.5",
     "globals": "^17.6.0",
     "npm-check-updates": "^22.1.1",
-    "prettier": "^3.8.3",
+    "prettier": "^3.9.6",
     "replace-in-file": "^8.4.0",
     "rimraf": "^6.1.3",
     "rollup": "^4.60.3",


### PR DESCRIPTION
Precondition the current development dependency batch by updating Prettier and applying its one README wrapping change. This keeps the Dependabot PR dependency-only, which is required for Garden provenance verification.

Validation: format check, lint, build, 66 tests, consumer smoke test, audit, and diff check all pass.